### PR TITLE
[WIP] Update the version of Xcode from 9.2.0 to 10.1.0

### DIFF
--- a/sample-ios-swift.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/sample-ios-swift.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Checklist

- [x] 1. Add `IDEWorkspaceChecks.plist` to the repository which is generated after Xcode 9.3
- [ ] 2. Update Carthage for Xcode 10.1.0 (Swift 4.2.1)
- [ ] 3. Update the version of Xcode from 9.2.0 to 10.1.0 on CirclrCI
- [ ] 4. (optional) Convert automatically from Swift 4.0.3 to Swift 4.2

### Motivation and Context

Build failed on CircleCI because the latest `swiftlint` requires Xcode 10.0 to be installed.
So, I updated Xcode (local and CircleCI) and Carthage (RxSwift).

### Description

1. The following is the reason why I commited `IDEWorkspaceChecks.plist`

```text
Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace’s shared data, to store the state of necessary workspace checks.
Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace.
```

2. Xcode 10.1.0 requires to update RxSwift for Swift 4.2.1

```text
/Users/lyuich/.go/src/github.com/lyuich/sample-ios-swift/sample-ios-swift/ViewController.swift:12:8: 
Module compiled with Swift 4.0.3 cannot be imported by the Swift 4.2.1 compiler:
/Users/lyuich/.go/src/github.com/lyuich/sample-ios-swift/Carthage/Build/iOS/RxSwift.framework/Modules/RxSwift.swiftmodule/x86_64.swiftmodule
```

3. The latest version of `swiftlint` requires Xcode 10.0 or later

```console
$ brew install swiftlint

swiftlint: A full installation of Xcode.app 10.0 is required to compile this software.
Installing just the Command Line Tools is not sufficient.
Xcode 10.0 cannot be installed on macOS 10.12.
You must upgrade your version of macOS.
Error: An unsatisfied requirement failed this build.
Exited with code 1
```

### Reference

- [Xcode Release Notes](https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-DontLinkElementID_7)